### PR TITLE
Add score layering to temper quality scores

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A toolkit for fetching arXiv preprints, generating structured reviews with
 OpenAI models, and optionally uploading the results to Arweave.  The project
 can now be used both as a library and as a command line tool.
 
+Set the environment variable `SCORE_LAYERS` to dampen overly generous quality
+scores.  Each additional layer further reduces the reported score.  The default
+is `2`.
+
 ## Library usage
 
 ```python


### PR DESCRIPTION
## Summary
- introduce `SCORE_LAYERS` env var to apply additional damping layers to quality scores
- add `apply_score_layers` helper and integrate into review pipeline
- document new score layering option in README

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6209e17e48323be8506ee767b4b63