### PR TITLE
Enable score layer configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ A toolkit for fetching arXiv preprints, generating structured reviews with
 OpenAI models, and optionally uploading the results to Arweave.  The project
 can now be used both as a library and as a command line tool.
 
-Set the environment variable `SCORE_LAYERS` to dampen overly generous quality
-scores.  Each additional layer further reduces the reported score.  The default
-is `2`.
+Set the environment variable `SCORE_LAYERS` (or pass `--score-layers` on the
+command line) to dampen overly generous quality scores.  Each additional layer
+further reduces the reported score.  The default is `2`.
 
 ## Library usage
 
@@ -26,6 +26,7 @@ process_papers(
     generate_graphql=False,
     serve_graphql=False,
     benchmark=False,
+    score_layers=2,
 )
 ```
 


### PR DESCRIPTION
## Summary
- Allow specifying score layers via `--score-layers` and `score_layers` parameter so model scores can be dampened programmatically.
- Record applied score layers in provenance metadata and export `SCORE_LAYERS` for library use.

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6223ad9e08323949b67a083360d09